### PR TITLE
fix name of BeforeRunTask for avoid name conflict on NamedDomainContainer

### DIFF
--- a/src/main/groovy/org/jetbrains/gradle/ext/RunConfigurations.groovy
+++ b/src/main/groovy/org/jetbrains/gradle/ext/RunConfigurations.groovy
@@ -174,7 +174,7 @@ class GradleTask extends BeforeRunTask {
     @Override
     Map<String, ?> toMap() {
         return super.toMap() << [
-                "projectPath": task.project.rootDir.absolutePath,
+                "projectPath": task.project.rootDir.absolutePath.replaceAll("\\\\", "/"),
                 "taskName": task.name
         ]
     }

--- a/src/main/groovy/org/jetbrains/gradle/ext/RunConfigurations.groovy
+++ b/src/main/groovy/org/jetbrains/gradle/ext/RunConfigurations.groovy
@@ -48,6 +48,7 @@ abstract class BaseRunConfiguration implements RunConfiguration {
     }
 }
 
+@CompileStatic
 abstract class JavaRunConfiguration extends BaseRunConfiguration {
     String workingDirectory
     String jvmArgs
@@ -58,9 +59,9 @@ abstract class JavaRunConfiguration extends BaseRunConfiguration {
 
     JavaRunConfiguration(Project project) {
         def beforeRun = GradleUtils.polymorphicContainer(project, BeforeRunTask)
-        beforeRun.registerFactory(Make, { project.objects.newInstance(Make) })
-        beforeRun.registerFactory(GradleTask, { project.objects.newInstance(GradleTask) })
-        beforeRun.registerFactory(BuildArtifact, { project.objects.newInstance(BuildArtifact) })
+        beforeRun.registerFactory(Make) { String name -> project.objects.newInstance(Make, name) }
+        beforeRun.registerFactory(GradleTask) { String name -> project.objects.newInstance(GradleTask, name) }
+        beforeRun.registerFactory(BuildArtifact) { String name -> project.objects.newInstance(BuildArtifact, name) }
         this.beforeRun = beforeRun
     }
 
@@ -80,6 +81,7 @@ abstract class JavaRunConfiguration extends BaseRunConfiguration {
     }
 }
 
+@CompileStatic
 class Application extends JavaRunConfiguration {
     String mainClass
     String moduleName
@@ -102,6 +104,7 @@ class Application extends JavaRunConfiguration {
     }
 }
 
+@CompileStatic
 class JarApplication extends JavaRunConfiguration {
     String jarPath
     String moduleName
@@ -125,10 +128,11 @@ class JarApplication extends JavaRunConfiguration {
 @CompileStatic
 abstract class BeforeRunTask implements Named, MapConvertible {
     protected String type
+    protected String name
 
     @Override
     String getName() {
-        return type
+        return name
     }
 
     @Override
@@ -142,7 +146,10 @@ class Make extends BeforeRunTask {
     Boolean enabled = true
 
     @Inject
-    Make() { this.@type = "make" }
+    Make(String name) {
+        this.@type = "make"
+        this.@name = name
+    }
 
     @Override
     Map<String, ?> toMap() {
@@ -155,7 +162,10 @@ class GradleTask extends BeforeRunTask {
     Task task
 
     @Inject
-    GradleTask() { this.@type = "gradleTask" }
+    GradleTask(String name) {
+        this.@type = "gradleTask"
+        this.@name = name
+    }
 
     @Override
     Map<String, ?> toMap() {
@@ -171,7 +181,10 @@ class BuildArtifact extends BeforeRunTask {
     String artifactName
 
     @Inject
-    BuildArtifact() { this.@type = "buildArtifact" }
+    BuildArtifact(String name) {
+        this.@type = "buildArtifact"
+        this.@name = name
+    }
 
     @Override
     Map<String, ?> toMap() {

--- a/src/main/groovy/org/jetbrains/gradle/ext/RunConfigurations.groovy
+++ b/src/main/groovy/org/jetbrains/gradle/ext/RunConfigurations.groovy
@@ -57,12 +57,16 @@ abstract class JavaRunConfiguration extends BaseRunConfiguration {
 
     final PolymorphicDomainObjectContainer<BeforeRunTask> beforeRun
 
-    JavaRunConfiguration(Project project) {
+    static PolymorphicDomainObjectContainer<BeforeRunTask> createBeforeRun(Project project) {
         def beforeRun = GradleUtils.polymorphicContainer(project, BeforeRunTask)
         beforeRun.registerFactory(Make) { String name -> project.objects.newInstance(Make, name) }
         beforeRun.registerFactory(GradleTask) { String name -> project.objects.newInstance(GradleTask, name) }
         beforeRun.registerFactory(BuildArtifact) { String name -> project.objects.newInstance(BuildArtifact, name) }
-        this.beforeRun = beforeRun
+        return beforeRun
+    }
+
+    JavaRunConfiguration(Project project) {
+        this.beforeRun = createBeforeRun(project)
     }
 
     def beforeRun(Action<PolymorphicDomainObjectContainer<BeforeRunTask>> action) {

--- a/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
+++ b/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
@@ -565,5 +565,79 @@ class SerializationTests {
       assertEquals(addCount, beforeRun.containerWithType(type.java).size)
     }
   }
+
+  @Test fun `test Make BeforeRunTask json output`() {
+    val beforeRun = JavaRunConfiguration.createBeforeRun(myProject)
+    beforeRun.create("make1", Make::class.java) {
+      it.enabled = true
+    }
+    beforeRun.create("make2", Make::class.java) {
+      it.enabled = false
+    }
+    assertEquals("""
+      |[
+      |    {
+      |        "type": "make",
+      |        "enabled": true
+      |    },
+      |    {
+      |        "type": "make",
+      |        "enabled": false
+      |    }
+      |]
+    """.trimMargin(),
+            JsonOutput.prettyPrint(JsonOutput.toJson(beforeRun.map { it.toMap() })))
+  }
+
+  @Test fun `test GradleTask BeforeRunTask json output`() {
+    val taskA = myProject.tasks.create("beforeRunTestA")
+    val taskB = myProject.tasks.create("beforeRunTestB")
+    val escapedRootProjectPath = myProject.projectDir.path.replace("\\", "/")
+    val beforeRun = JavaRunConfiguration.createBeforeRun(myProject)
+    beforeRun.create("gradleTask1", GradleTask::class.java) {
+      it.task = taskA
+    }
+    beforeRun.create("gradleTask2", GradleTask::class.java) {
+      it.task = taskB
+    }
+    assertEquals("""
+      |[
+      |    {
+      |        "type": "gradleTask",
+      |        "projectPath": "$escapedRootProjectPath",
+      |        "taskName": "${taskA.name}"
+      |    },
+      |    {
+      |        "type": "gradleTask",
+      |        "projectPath": "$escapedRootProjectPath",
+      |        "taskName": "${taskB.name}"
+      |    }
+      |]
+    """.trimMargin(),
+      JsonOutput.prettyPrint(JsonOutput.toJson(beforeRun.map { it.toMap() })))
+  }
+
+  @Test fun `test BuildArtifact BeforeRunTask json output`() {
+    val beforeRun = JavaRunConfiguration.createBeforeRun(myProject)
+    beforeRun.create("buildArtifact1", BuildArtifact::class.java) {
+      it.artifactName = "myName1"
+    }
+    beforeRun.create("buildArtifact2", BuildArtifact::class.java) {
+      it.artifactName = "myName2"
+    }
+    assertEquals("""
+      |[
+      |    {
+      |        "type": "buildArtifact",
+      |        "artifactName": "myName1"
+      |    },
+      |    {
+      |        "type": "buildArtifact",
+      |        "artifactName": "myName2"
+      |    }
+      |]
+    """.trimMargin(),
+            JsonOutput.prettyPrint(JsonOutput.toJson(beforeRun.map { it.toMap() })))
+  }
 }
 

--- a/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
+++ b/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
@@ -7,6 +7,7 @@ import org.gradle.api.internal.provider.DefaultProvider
 import org.gradle.testfixtures.ProjectBuilder
 import org.intellij.lang.annotations.Language
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import java.io.File
@@ -551,21 +552,6 @@ class SerializationTests {
 
   }
 
-  @Test fun `test multiple BeforeRunTasks of same type`() {
-    val beforeRun = JavaRunConfiguration.createBeforeRun(myProject)
-    val addCount = 2
-    listOf(Make::class, GradleTask::class, BuildArtifact::class).forEach { type ->
-      repeat(addCount) { i ->
-        val name = "${type.simpleName}$i"
-        beforeRun.create(name, type.java)
-        // Checks the name equals with the given $name.
-        assertEquals(name, beforeRun.findByName(name)?.getName())
-      }
-      // Checks the tasks properly added $addCount times.
-      assertEquals(addCount, beforeRun.containerWithType(type.java).size)
-    }
-  }
-
   @Test fun `test Make BeforeRunTask json output`() {
     val beforeRun = JavaRunConfiguration.createBeforeRun(myProject)
     beforeRun.create("make1", Make::class.java) {
@@ -574,6 +560,8 @@ class SerializationTests {
     beforeRun.create("make2", Make::class.java) {
       it.enabled = false
     }
+    assertNotNull(beforeRun.findByName("make1"))
+    assertNotNull(beforeRun.findByName("make2"))
     assertEquals("""
       |[
       |    {
@@ -600,6 +588,8 @@ class SerializationTests {
     beforeRun.create("gradleTask2", GradleTask::class.java) {
       it.task = taskB
     }
+    assertNotNull(beforeRun.findByName("gradleTask1"))
+    assertNotNull(beforeRun.findByName("gradleTask2"))
     assertEquals("""
       |[
       |    {
@@ -625,6 +615,8 @@ class SerializationTests {
     beforeRun.create("buildArtifact2", BuildArtifact::class.java) {
       it.artifactName = "myName2"
     }
+    assertNotNull(beforeRun.findByName("buildArtifact1"))
+    assertNotNull(beforeRun.findByName("buildArtifact2"))
     assertEquals("""
       |[
       |    {

--- a/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
+++ b/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
@@ -551,6 +551,19 @@ class SerializationTests {
 
   }
 
-
+  @Test fun `test multiple BeforeRunTasks of same type`() {
+    val beforeRun = JavaRunConfiguration.createBeforeRun(myProject)
+    val addCount = 2
+    listOf(Make::class, GradleTask::class, BuildArtifact::class).forEach { type ->
+      repeat(addCount) { i ->
+        val name = "${type.simpleName}$i"
+        beforeRun.create(name, type.java)
+        // Checks the name equals with the given $name.
+        assertEquals(name, beforeRun.findByName(name)?.getName())
+      }
+      // Checks the tasks properly added $addCount times.
+      assertEquals(addCount, beforeRun.containerWithType(type.java).size)
+    }
+  }
 }
 

--- a/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
+++ b/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
@@ -39,12 +39,12 @@ class SerializationTests {
     |    "workingDirectory": null,
     |    "beforeRun": [
     |        {
-    |            "type": "buildArtifact",
-    |            "artifactName": "myName"
-    |        },
-    |        {
     |            "type": "make",
     |            "enabled": false
+    |        },
+    |        {
+    |            "type": "buildArtifact",
+    |            "artifactName": "myName"
     |        }
     |    ],
     |    "jvmArgs": null,
@@ -76,12 +76,12 @@ class SerializationTests {
     |    "workingDirectory": null,
     |    "beforeRun": [
     |        {
-    |            "type": "buildArtifact",
-    |            "artifactName": "myName"
-    |        },
-    |        {
     |            "type": "make",
     |            "enabled": false
+    |        },
+    |        {
+    |            "type": "buildArtifact",
+    |            "artifactName": "myName"
     |        }
     |    ],
     |    "jvmArgs": null,


### PR DESCRIPTION
Currently, we can't add the `before run` with same type. it caused by returning the same name on each `BeforeRunTask#getName()`.
So, I fixed it to return the user defined name instead of `BeforeRunTask#getType()`. 
Additionally, I added `@CompileStatic` on `JavaRunConfiguration` for performance.

Reproduce code:
```groovy
idea.project.settings.runConfigurations {
    'sample'(Application) {
        beforeRun {
            'sameGradleButA'(GradleTask) { task = tasks.getByName("clean") }
            'sameGradleButB'(GradleTask) { task = tasks.getByName("build") }
        }
    }
}
```