### PR TITLE
#111 - Support import of Javac compiler parameters per-module from Gradle

### DIFF
--- a/src/main/groovy/org/jetbrains/gradle/ext/Compiler.groovy
+++ b/src/main/groovy/org/jetbrains/gradle/ext/Compiler.groovy
@@ -61,6 +61,7 @@ class IdeaCompilerConfiguration implements MapConvertible {
 class JavacConfiguration {
     Boolean preferTargetJDKCompiler
     String javacAdditionalOptions
+    Map<String, String> moduleJavacAdditionalOptions
     Boolean generateDebugInfo
     Boolean generateDeprecationWarnings
     Boolean generateNoWarnings
@@ -69,6 +70,7 @@ class JavacConfiguration {
         def map = [:]
         if (preferTargetJDKCompiler != null) map.put("preferTargetJDKCompiler", preferTargetJDKCompiler)
         if (javacAdditionalOptions != null) map.put("javacAdditionalOptions", javacAdditionalOptions)
+        if (moduleJavacAdditionalOptions != null) map.put("moduleJavacAdditionalOptions", moduleJavacAdditionalOptions)
         if (generateDebugInfo != null) map.put("generateDebugInfo", generateDebugInfo)
         if (generateDeprecationWarnings != null) map.put("generateDeprecationWarnings", generateDeprecationWarnings)
         if (generateNoWarnings != null) map.put("generateNoWarnings", generateNoWarnings)

--- a/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
+++ b/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
@@ -327,6 +327,7 @@ class SerializationTests {
       javac {
         it.preferTargetJDKCompiler = false
         it.javacAdditionalOptions = "-Xmaxwarns 999"
+        it.moduleJavacAdditionalOptions = mapOf("some.test" to "-Xmaxwarns 899", "some.core" to "-Xmaxwarns 799")
       }
       additionalVmOptions = "-Xms120"
       useReleaseOption = false
@@ -340,7 +341,11 @@ class SerializationTests {
       |    "useReleaseOption": false,
       |    "javacOptions": {
       |        "preferTargetJDKCompiler": false,
-      |        "javacAdditionalOptions": "-Xmaxwarns 999"
+      |        "javacAdditionalOptions": "-Xmaxwarns 999",
+      |        "moduleJavacAdditionalOptions": {
+      |            "some.test": "-Xmaxwarns 899",
+      |            "some.core": "-Xmaxwarns 799"
+      |        }
       |    }
       |}
       """.trimMargin(),


### PR DESCRIPTION
Example of usage:

```
idea.project.settings {
    compiler {
        javac {
            javacAdditionalOptions '-parameters'
            moduleJavacAdditionalOptions = ['some' : '-aaa',
                                            'some.main' : '-bbb',
                                            'some.test' : '-ccc',
                                            'some.core' : '-ddd']
        }
    }
}
```

![image](https://user-images.githubusercontent.com/45571812/90637334-870a5700-e234-11ea-9657-e90667ceb6bf.png)

In this example the compiler parameters of the `some.core` module are ignored because this module doesn't exist. So the updated `.idea/compiler.xml` remains correct.

This pull request depends on https://github.com/JetBrains/intellij-community/pull/1430
Also see https://youtrack.jetbrains.com/issue/IDEA-248525