### PR TITLE
Fix tests failing when there is a UTF-8 character in path.

### DIFF
--- a/src/test/groovy/TestIdeaExtPlugin.groovy
+++ b/src/test/groovy/TestIdeaExtPlugin.groovy
@@ -6,6 +6,8 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
+import static groovy.json.StringEscapeUtils.escapeJava
+
 class IdeaModelExtensionFunctionalTest extends Specification {
   @Rule
   TemporaryFolder testProjectDir = new TemporaryFolder()
@@ -235,7 +237,7 @@ task printSettings {
                                 {
                                     "type": "FILE",
                                     "sourceFiles": [
-                                        "${buildFile.canonicalPath.replace('\\\\' as char, '/' as char)}"
+                                        "${escapeJava(buildFile.canonicalPath.replace('\\\\' as char, '/' as char))}"
                                     ]
                                 }
                             ]
@@ -486,7 +488,7 @@ task printSettings {
             .build()
     then:
     def lines = result.output.readLines()
-    def moduleContentRoot = testProjectDir.root.canonicalPath.replace(File.separator, '/')
+    def moduleContentRoot = escapeJava(testProjectDir.root.canonicalPath.replace(File.separator, '/'))
     lines[1] == '{"packagePrefix":{' +
             '"' + moduleContentRoot + '/main/groovy":"com.example.main.groovy",' +
             '"' + moduleContentRoot + '/test/java":"com.example.test.java"' +
@@ -538,7 +540,7 @@ task printSettings {
             .build()
     then:
     def lines = result.output.readLines()
-    def moduleContentRoot = testProjectDir.root.canonicalPath.replace(File.separator, '/')
+    def moduleContentRoot = escapeJava(testProjectDir.root.canonicalPath.replace(File.separator, '/'))
     lines[0] == '{"packagePrefix":{' +
             '"' + moduleContentRoot + '/src":"com.example.java",' +
             '"' + moduleContentRoot + '/../subproject/src":"com.example.java.sub"' +
@@ -588,7 +590,7 @@ task printSettings {
             .build()
     then:
     def lines = result.output.readLines()
-    def moduleContentRoot = testProjectDir.root.canonicalPath.replace(File.separator, '/')
+    def moduleContentRoot = escapeJava(testProjectDir.root.canonicalPath.replace(File.separator, '/'))
     lines[0] == '{"packagePrefix":{"' + moduleContentRoot + '/src":"com.example.java"}}'
 
     result.task(":printSettings").outcome == TaskOutcome.SUCCESS
@@ -1013,7 +1015,7 @@ import org.jetbrains.gradle.ext.*
     then:
 
     def lines = result.output.readLines()
-    def projectDir = lines[3]
+    def projectDir = escapeJava(lines[3])
     "LazyFlag before=[false]" == lines[0]
     "LazyFlag after=[true]"   == lines[2]
     def prettyOutput = JsonOutput.prettyPrint(lines[1])

--- a/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
+++ b/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
@@ -2,6 +2,7 @@ package org.jetbrains.gradle.ext
 
 import com.google.gson.JsonParser
 import groovy.json.JsonOutput
+import groovy.json.StringEscapeUtils.escapeJava
 import org.gradle.api.NamedDomainObjectCollection
 import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
@@ -389,8 +390,8 @@ class SerializationTests {
       afterRebuild(subTasks.getByName("subtask"))
     }
 
-    val escapedRootProjectPath = myProject.projectDir.path.replace("\\", "/")
-    val subProjectPath = subProject.projectDir.path.replace("\\", "/")
+    val escapedRootProjectPath = escapeJava(myProject.projectDir.path.replace("\\", "/"))
+    val subProjectPath = escapeJava(subProject.projectDir.path.replace("\\", "/"))
 
     assertEquals("""
       |{
@@ -448,7 +449,9 @@ class SerializationTests {
     val filePath = File(rootDir, "file.txt").apply {
       createNewFile()
       writeText("Some text")
-    }.path.replace('\\', '/')
+    }.path.replace('\\', '/').let {
+      escapeJava(it)
+    }
 
     val dirPath = File(rootDir, "dir").apply {
       mkdirs()
@@ -456,11 +459,14 @@ class SerializationTests {
         createNewFile()
         writeText("Some text in subdirectory")
       }
-    }.path.replace('\\', '/')
+    }.path.replace('\\', '/').let {
+      escapeJava(it)
+    }
 
     val archivePath = File(rootDir, "my.zip")
             .apply { createNewFile() }
             .path.replace('\\', '/')
+            .let { escapeJava(it) }
 
     val configurationName = "testCfg"
     val testCfg = myProject.configurations.create(configurationName)
@@ -592,7 +598,7 @@ class SerializationTests {
   @Test fun `test GradleTask BeforeRunTask json output`() {
     val taskA = myProject.tasks.create("beforeRunTestA")
     val taskB = myProject.tasks.create("beforeRunTestB")
-    val escapedRootProjectPath = myProject.projectDir.path.replace("\\", "/")
+    val escapedRootProjectPath = escapeJava(myProject.projectDir.path.replace("\\", "/"))
     val beforeRun = JavaRunConfiguration.createBeforeRun(myProject)
     beforeRun.create("gradleTask1", GradleTask::class.java) {
       it.task = taskA


### PR DESCRIPTION
Several tests call `groovy.json.JsonOutput#prettyPrint` to generate prettied JSON. This method calls `org.apache.groovy.json.internal.CharBuf#addJsonEscapedString` which escapes characters and replaces them by `\uXXXX`. For example `C:/Users/Michał/AppData/Local/Temp/junit2652868285747475185/main/groovy` becomes `C:/Users/Micha\u0142/AppData/Local/Temp/junit2652868285747475185/main/groovy`, so tests are failing because Strings aren't equal.

I've used `groovy.json.StringEscapeUtils#escapeJava()`, so paths interpolated into JSONs in source code are also escaped.

<details>
Example test result:

```
Condition not satisfied:

lines[1] == '{"packagePrefix":{' + '"' + moduleContentRoot + '/main/groovy":"com.example.main.groovy",' + '"' + moduleContentRoot + '/test/java":"com.example.test.java"' + '}}'
|    |   |                       |     | |                 |                                            |     | |                 |                                       |
|    |   |                       |     | |                 |                                            |     | |                 |                                       {"packagePrefix":{"C:/Users/Michał/AppData/Local/Temp/junit2652868285747475185/main/groovy":"com.example.main.groovy","C:/Users/Michał/AppData/Local/Temp/junit2652868285747475185/test/java":"com.example.test.java"}}
|    |   |                       |     | |                 |                                            |     | |                 {"packagePrefix":{"C:/Users/Michał/AppData/Local/Temp/junit2652868285747475185/main/groovy":"com.example.main.groovy","C:/Users/Michał/AppData/Local/Temp/junit2652868285747475185/test/java":"com.example.test.java"
|    |   |                       |     | |                 |                                            |     | C:/Users/Michał/AppData/Local/Temp/junit2652868285747475185
|    |   |                       |     | |                 |                                            |     {"packagePrefix":{"C:/Users/Michał/AppData/Local/Temp/junit2652868285747475185/main/groovy":"com.example.main.groovy","C:/Users/Michał/AppData/Local/Temp/junit2652868285747475185
|    |   |                       |     | |                 |                                            {"packagePrefix":{"C:/Users/Michał/AppData/Local/Temp/junit2652868285747475185/main/groovy":"com.example.main.groovy","
|    |   |                       |     | |                 {"packagePrefix":{"C:/Users/Michał/AppData/Local/Temp/junit2652868285747475185/main/groovy":"com.example.main.groovy",
|    |   |                       |     | C:/Users/Michał/AppData/Local/Temp/junit2652868285747475185
|    |   |                       |     {"packagePrefix":{"C:/Users/Michał/AppData/Local/Temp/junit2652868285747475185
|    |   |                       {"packagePrefix":{"
|    |   false
|    |   12 differences (94% similarity)
|    |   {"packagePrefix":{"C:/Users/Micha(\\u0142)/AppData/Local/Temp/junit2652868285747475185/main/groovy":"com.example.main.groovy","C:/Users/Micha(\\u0142)/AppData/Local/Temp/junit2652868285747475185/test/java":"com.example.test.java"}}
|    |   {"packagePrefix":{"C:/Users/Micha(ł~-----)/AppData/Local/Temp/junit2652868285747475185/main/groovy":"com.example.main.groovy","C:/Users/Micha(ł~-----)/AppData/Local/Temp/junit2652868285747475185/test/java":"com.example.test.java"}}
|    {"packagePrefix":{"C:/Users/Micha\u0142/AppData/Local/Temp/junit2652868285747475185/main/groovy":"com.example.main.groovy","C:/Users/Micha\u0142/AppData/Local/Temp/junit2652868285747475185/test/java":"com.example.test.java"}}
[C:\Users\Michał\AppData\Local\Temp\junit2652868285747475185, {"packagePrefix":{"C:/Users/Micha\u0142/AppData/Local/Temp/junit2652868285747475185/main/groovy":"com.example.main.groovy","C:/Users/Micha\u0142/AppData/Local/Temp/junit2652868285747475185/test/java":"com.example.test.java"}}]

	at IdeaModelExtensionFunctionalTest.test module package prefix settings(TestIdeaExtPlugin.groovy:490)
```
</details>