### PR TITLE
Add missing annotation to BuildIdeArtifact

### DIFF
--- a/src/main/groovy/org/jetbrains/gradle/ext/IdeArtifacts.groovy
+++ b/src/main/groovy/org/jetbrains/gradle/ext/IdeArtifacts.groovy
@@ -8,6 +8,7 @@ import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
@@ -429,8 +430,16 @@ enum ArtifactType {
 
 class BuildIdeArtifact extends DefaultTask {
   public static final String DEFAULT_DESTINATION = "idea-artifacts"
+
+  @Internal
   RecursiveArtifact artifact
   File outputDirectory = null
+
+  BuildIdeArtifact() {
+    // The artifact cannot be used as input, so the task cannot declare its inputs
+    // and should always be out-of-date.
+    outputs.upToDateWhen { false }
+  }
 
   @TaskAction
   void createArtifact() {


### PR DESCRIPTION
Without the annotation, the task won't work on Gradle 7.x