### PR TITLE
Add support for configuring web resource directories in Web facets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
   id 'java-gradle-plugin'
   id "org.jetbrains.kotlin.jvm" version "1.3.61"
   id "com.gradle.plugin-publish" version "0.11.0"
+  id 'maven-publish'
 }
 
 group = 'org.jetbrains.gradle.plugin.idea-ext'

--- a/src/main/groovy/org/jetbrains/gradle/ext/Facets.groovy
+++ b/src/main/groovy/org/jetbrains/gradle/ext/Facets.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.Action
 import org.gradle.api.Named
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
 
 import javax.inject.Inject
 
@@ -54,6 +55,32 @@ class SpringContext {
                 "file"  : file,
                 "name"  : name,
                 "parent": parent
+        ]
+    }
+}
+
+class WebFacet implements Facet {
+
+    final String name
+    final String type = "web"
+
+    SourceSet sourceSet
+    Map<String, String> webRoots
+
+    Project project
+
+    @Inject
+    WebFacet(String name, Project project) {
+        this.project = project
+        this.name = name
+    }
+
+    Map<String, ?> toMap() {
+        return [
+                "type"     : type,
+                "sourceSet": sourceSet?.name ?: 'main',
+                "webRoots" : webRoots.collectEntries { source, target -> [project.file(source).path, target]},
+                "name"     : name
         ]
     }
 }

--- a/src/main/groovy/org/jetbrains/gradle/ext/IdeaExtPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/gradle/ext/IdeaExtPlugin.groovy
@@ -195,6 +195,7 @@ class ModuleSettings extends AbstractExtensibleSettings {
     def facets = GradleUtils.polymorphicContainer(project, Facet)
 
     facets.registerFactory(SpringFacet) { String name -> project.objects.newInstance(SpringFacet, name, project) }
+    facets.registerFactory(WebFacet) { String name -> project.objects.newInstance(WebFacet, name, project) }
     this.facets = facets
     ideaFilesProcessor = processor
   }

--- a/src/test/groovy/TestIdeaExtPlugin.groovy
+++ b/src/test/groovy/TestIdeaExtPlugin.groovy
@@ -416,6 +416,13 @@ task printSettings {
                       }
                     }
                   }
+                  web(WebFacet) {
+                      sourceSet = sourceSets.main
+                      webRoots = [
+                        'resources/test1': 'test1',
+                        'resources/test2': 'test2'
+                      ]
+                  }
                 }
                 
                 rootModuleType = "SOME_TYPE"
@@ -446,7 +453,11 @@ task printSettings {
         lines[1] == '{"moduleType":{"":"SOME_TYPE","main":"JAVA_MODULE","test":"PYTHON_MODULE"},' +
                 '"facets":[{"type":"spring","contexts":' +
                 '[{"file":"spring_parent.xml","name":"p1","parent":null},' +
-                '{"file":"spring_new_child.xml","name":"p2","parent":"p1"}],"name":"spring"}]}'
+                '{"file":"spring_new_child.xml","name":"p2","parent":"p1"}],"name":"spring"},' +
+                '{"type":"web","sourceSet":"main","webRoots":{"' +
+                new File(testProjectDir.root, 'resources/test1').canonicalPath + '":"test1","' +
+                new File(testProjectDir.root, 'resources/test2').canonicalPath + '":"test2"' +
+                '},"name":"web"}]}'
 
         result.task(":printSettings").outcome == TaskOutcome.SUCCESS
 


### PR DESCRIPTION
In web projects it is important to be able to configure web resource directories for various purposes. 

Because I cannot create a pull request for IntelliJ Ultimate, support on the IDE side has been added in a plugin located at 

https://github.com/ingokegel/intellij-web-facet-importer

The plugin has been published in the marketplace:

https://plugins.jetbrains.com/plugin/18139-web-facet-importer

The source code is in the public domain and can be used for IntelliJ Ultimate by JetBrains.