### PR TITLE
Ease IdeaModel configuration through Kotlin extensions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.ProjectExtensionsKt
+
 plugins {
   id 'groovy'
   id 'java-gradle-plugin'
@@ -15,6 +17,8 @@ repositories {
 dependencies {
   implementation 'com.google.code.gson:gson:2.8.6'
   implementation 'com.google.guava:guava:28.2-jre'
+  implementation ProjectExtensionsKt.gradleKotlinDsl(project)
+
   testImplementation 'org.jetbrains.kotlin:kotlin-stdlib'
   testImplementation('org.spockframework:spock-core:1.3-groovy-2.5') {
     exclude group: 'org.codehaus.groovy'
@@ -50,3 +54,7 @@ wrapper {
   gradleVersion = "5.6.4"
   distributionType = Wrapper.DistributionType.BIN
 }
+
+compileGroovy.dependsOn.remove('compileJava')
+compileKotlin.dependsOn compileGroovy
+compileKotlin.classpath += files(compileGroovy.destinationDir)

--- a/src/main/kotlin/org/jetbrains/gradle/ext/IdeaModelUtils.kt
+++ b/src/main/kotlin/org/jetbrains/gradle/ext/IdeaModelUtils.kt
@@ -1,0 +1,19 @@
+package org.jetbrains.gradle.ext
+
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.the
+import org.gradle.plugins.ide.idea.model.IdeaModel
+
+val IdeaModel.settings: ProjectSettings
+    get() = (this.project as ExtensionAware).the()
+
+fun IdeaModel.settings(configure: ProjectSettings.() -> Unit) {
+    configure(this.settings)
+}
+
+val ProjectSettings.compiler: IdeaCompilerConfiguration
+    get() = (this as ExtensionAware).the()
+
+fun ProjectSettings.compiler(configure: IdeaCompilerConfiguration.() -> Unit) {
+    configure(this.compiler)
+}

--- a/src/test/groovy/TestIdeaExtPluginOnKotlinBuildFile.groovy
+++ b/src/test/groovy/TestIdeaExtPluginOnKotlinBuildFile.groovy
@@ -1,0 +1,84 @@
+import groovy.json.JsonOutput
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class IdeaModelExtensionOnKotlinBuildFileFunctionalTest extends Specification {
+    @Rule
+    TemporaryFolder testProjectDir = new TemporaryFolder()
+    File buildFile
+    File settingsFile
+
+    static List<String> gradleVersionList = ["5.0", "5.6.4", "6.0", "6.8.3", "7.0", "7.2", "7.3"]
+
+    def setup() {
+        buildFile = testProjectDir.newFile('build.gradle.kts')
+        settingsFile = testProjectDir.newFile('settings.gradle.kts')
+    }
+
+    def "test compiler settings"() {
+        given:
+        settingsFile << """
+rootProject.name = "ProjectName"
+"""
+        // language=kotlin
+        buildFile << """
+      import org.jetbrains.gradle.ext.*
+
+      plugins {
+        id ("org.jetbrains.gradle.plugin.idea-ext")
+      }
+      idea {
+        settings {
+          compiler {
+            processHeapSize = 8192
+            parallelCompilation = false
+            javac {
+              javacAdditionalOptions = listOf(
+                "-Werror",
+                "-Xlint:all",
+                "-Xlint:-options",
+                "-Xlint:-serial",
+                "-proc:none",
+                "-Xdiags:verbose",
+                "-parameters"
+              ).joinToString(separator = " ")
+            }
+          }
+        }
+      }
+
+      tasks.register("printSettings") {
+        doLast {
+          println(project.idea.settings.toString())
+        }
+      }
+    """
+        when:
+        def result = GradleRunner.create()
+            .withGradleVersion(gradleVersion)
+            .withProjectDir(testProjectDir.root)
+            .withArguments("printSettings", "-q")
+            .withPluginClasspath()
+            .build()
+        then:
+
+        def lines = result.output.readLines()
+        def prettyOutput = JsonOutput.prettyPrint(lines[0])
+        prettyOutput.contains(
+            """"compiler": {
+        "processHeapSize": 8192,
+        "parallelCompilation": false,
+        "javacOptions": {
+            "javacAdditionalOptions": "-Werror -Xlint:all -Xlint:-options -Xlint:-serial -proc:none -Xdiags:verbose -parameters"
+        }
+    }""")
+
+        result.task(":printSettings").outcome == TaskOutcome.SUCCESS
+        where:
+        gradleVersion << gradleVersionList
+    }
+
+}


### PR DESCRIPTION
Goal is to be able to use idiomatic configuration blocks in `build.gradle.kts` like below:

```
idea {
    settings {
        compiler {
            processHeapSize = 4096
            parallelCompilation = false
            javac {
                javacAdditionalOptions = listOf(
                    "-Werror",
                    "-Xlint:all",
                    "-Xlint:-options",
                    "-Xlint:-serial",
                    "-proc:none",
                    "-Xdiags:verbose",
                    "-parameters"
                ).joinToString(separator = " ")
            }
        }
    }
}
```