### PR TITLE
Fix `beforeRun` `GradleTask` selecting the incorrect 'projectPath'.

### DIFF
--- a/src/main/groovy/org/jetbrains/gradle/ext/RunConfigurations.groovy
+++ b/src/main/groovy/org/jetbrains/gradle/ext/RunConfigurations.groovy
@@ -210,7 +210,7 @@ class GradleTask extends BeforeRunTask {
     @Override
     Map<String, ?> toMap() {
         return super.toMap() << [
-                "projectPath": task.project.rootDir.absolutePath.replaceAll("\\\\", "/"),
+                "projectPath": task.project.projectDir.absolutePath.replaceAll("\\\\", "/"),
                 "taskName": task.name
         ]
     }


### PR DESCRIPTION
The use of `rootDir` here is incorrect as it returns the root directory of the root project as per the [Gradle documentation](https://docs.gradle.org/current/dsl/org.gradle.api.Project.html).

This makes it impossible to select the task of a sub-project to be executed as a `beforeRun` action, as the `projectPath` field in the generated run configs, always points to `$PROJECT_DIR$` resulting in the incorrect Gradle task being executed.

This change simply switches to using `projectDir` instead, resulting in the correct run configs being generated.

Please let me know if anything else is required, test cases/test/etc.
Thanks.