### PR TITLE
Allow all run configurations to specify BeforeRun actions.

### DIFF
--- a/src/main/groovy/org/jetbrains/gradle/ext/IdeaExtPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/gradle/ext/IdeaExtPlugin.groovy
@@ -55,10 +55,10 @@ class IdeaExtPlugin implements Plugin<Project> {
     RunConfigurationContainer runConfigurations = GradleUtils.runConfigurationsContainer(project)
 
     runConfigurations.registerFactory(Application) { String name -> project.objects.newInstance(Application, name, project) }
-    runConfigurations.registerFactory(JUnit) { String name -> project.objects.newInstance(JUnit, name) }
-    runConfigurations.registerFactory(Remote) { String name -> project.objects.newInstance(Remote, name) }
-    runConfigurations.registerFactory(TestNG) { String name -> project.objects.newInstance(TestNG, name) }
-    runConfigurations.registerFactory(Gradle) { String name -> project.objects.newInstance(Gradle, name) }
+    runConfigurations.registerFactory(JUnit) { String name -> project.objects.newInstance(JUnit, name, project) }
+    runConfigurations.registerFactory(Remote) { String name -> project.objects.newInstance(Remote, name, project) }
+    runConfigurations.registerFactory(TestNG) { String name -> project.objects.newInstance(TestNG, name, project) }
+    runConfigurations.registerFactory(Gradle) { String name -> project.objects.newInstance(Gradle, name, project) }
     runConfigurations.registerFactory(JarApplication) { String name -> project.objects.newInstance(JarApplication, name, project) }
 
     container.add(RunConfigurationContainer, "runConfigurations", runConfigurations)

--- a/src/test/groovy/TestIdeaExtPlugin.groovy
+++ b/src/test/groovy/TestIdeaExtPlugin.groovy
@@ -102,9 +102,9 @@ rootProject.name = "ProjectName"
             "defaults": false,
             "type": "application",
             "name": "Run my app",
+            "beforeRun": [],
             "moduleName": "ProjectName",
             "workingDirectory": ${new Gson().toJson(projectDir)},
-            "beforeRun": [],
             "mainClass": "foo.App",
             "includeProvidedDependencies": true
         },
@@ -726,7 +726,7 @@ class MyRC extends BaseRunConfiguration {
   def aKey = "a value"
   def type = "myRunConfiguration"
   @Inject
-  MyRC(String param) { name = param }
+  MyRC(String param, Project project) { super(project); name = param }
   String getName() { return name }
   String getType() { return type }
   Map<String, Object> toMap() { return [ "name": name, "type":type, "aKey": aKey ] } 
@@ -749,7 +749,7 @@ class TestPlugin implements Plugin<Project> {
         def ideaModel = project.extensions.findByName('idea') as IdeaModel
     
         def projectSettings = (ideaModel.project as ExtensionAware).extensions.findByName("settings") as ProjectSettings
-        projectSettings.runConfigurations.registerFactory(MyRC) { String name -> project.objects.newInstance(MyRC, name) }
+        projectSettings.runConfigurations.registerFactory(MyRC) { String name -> project.objects.newInstance(MyRC, name, project) }
         
         def moduleSettings = (ideaModel.module as ExtensionAware).extensions.findByName("settings") as ModuleSettings
         moduleSettings.facets.registerFactory(MyFacet) { String name -> project.objects.newInstance(MyFacet, name) }

--- a/src/test/groovy/TestIdeaExtPluginOnKotlinBuildFile.groovy
+++ b/src/test/groovy/TestIdeaExtPluginOnKotlinBuildFile.groovy
@@ -215,9 +215,9 @@ rootProject.name = "ProjectName"
             "defaults": false,
             "type": "application",
             "name": "Run my app",
+            "beforeRun": [],
             "moduleName": "ProjectName",
             "workingDirectory": ${new Gson().toJson(projectDir)},
-            "beforeRun": [],
             "mainClass": "foo.App",
             "includeProvidedDependencies": true
         },

--- a/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
+++ b/src/test/kotlin/org/jetbrains/gradle/ext/SerializationTests.kt
@@ -49,9 +49,6 @@ class SerializationTests {
     |    "defaults": false,
     |    "type": "application",
     |    "name": "test",
-    |    "moduleName": "test",
-    |    "envs": null,
-    |    "workingDirectory": null,
     |    "beforeRun": [
     |        {
     |            "type": "make",
@@ -62,6 +59,9 @@ class SerializationTests {
     |            "artifactName": "myName"
     |        }
     |    ],
+    |    "moduleName": "test",
+    |    "envs": null,
+    |    "workingDirectory": null,
     |    "jvmArgs": null,
     |    "programParameters": null,
     |    "mainClass": null,
@@ -87,9 +87,6 @@ class SerializationTests {
     |    "defaults": false,
     |    "type": "jarApplication",
     |    "name": "test",
-    |    "moduleName": null,
-    |    "envs": null,
-    |    "workingDirectory": null,
     |    "beforeRun": [
     |        {
     |            "type": "make",
@@ -100,6 +97,9 @@ class SerializationTests {
     |            "artifactName": "myName"
     |        }
     |    ],
+    |    "moduleName": null,
+    |    "envs": null,
+    |    "workingDirectory": null,
     |    "jvmArgs": null,
     |    "programParameters": null,
     |    "jarPath": "myJarPath"
@@ -110,7 +110,7 @@ class SerializationTests {
 
   @Test
   fun `test remote json output`() {
-    val remote = Remote("remote debug").apply {
+    val remote = Remote("remote debug", myProject).apply {
       host = "hostname"
       port = 1234
       sharedMemoryAddress = "jvmdebug"
@@ -122,6 +122,7 @@ class SerializationTests {
         "defaults": false,
         "type": "remote",
         "name": "remote debug",
+        "beforeRun": [],
         "mode": "ATTACH",
         "port": 1234,
         "transport": "SOCKET",
@@ -134,7 +135,7 @@ class SerializationTests {
 
   @Test
   fun `test JUnit config output`() {
-    val config = JUnit("myName").apply {
+    val config = JUnit("myName", myProject).apply {
       className = "my.TestClass"
       repeat = "untilFailure"
       workingDirectory = "myWorkDir"
@@ -152,6 +153,7 @@ class SerializationTests {
                     "defaults": true,
                     "type": "junit",
                     "name": "myName",
+                    "beforeRun": [],
                     "moduleName": "myModule",
                     "directory": null,
                     "repeat": "untilFailure",
@@ -174,7 +176,7 @@ class SerializationTests {
   }
 
   @Test fun `test TestNG config output`() {
-    val config = TestNG("myName").apply {
+    val config = TestNG("myName", myProject).apply {
       className = "my.TestClass"
 
       workingDirectory = "myWorkDir"
@@ -192,6 +194,7 @@ class SerializationTests {
           "defaults": true,
           "type": "testng",
           "name": "myName",
+          "beforeRun": [],
           "moduleName": "myModule",
           "package": null,
           "class": "my.TestClass",
@@ -215,7 +218,7 @@ class SerializationTests {
   @Test
   fun `test Gradle run configuration output`() {
     val absolutePath = File("").absolutePath.replace("\\", "/")
-    val config = Gradle("gradleName").apply {
+    val config = Gradle("gradleName", myProject).apply {
       projectPath = absolutePath
       taskNames = listOf(":cleanTest", ":test")
       jvmArgs = "-Dkey=val"
@@ -230,6 +233,7 @@ class SerializationTests {
           "defaults": true,
           "type": "gradle",
           "name": "gradleName",
+          "beforeRun": [],
           "projectPath": "$absolutePath",
           "taskNames": [
               ":cleanTest",


### PR DESCRIPTION
Allows specifying BeforeRun actions for any run configuration.

This is already supported by the [layout importer inside IJ](https://github.com/JetBrains/intellij-community/blob/master/platform/external-system-impl/src/com/intellij/openapi/externalSystem/service/project/settings/RunConfigurationHandler.kt) for any run configuration it processes.

Unfortunately, this has some minor binary breaks for custom implementations of `BaseRunConfiguration` or children, as `Project` needs to be passed through. This can be changed to preserve binary compatibility if required.

Please let me know if any of the unit tests should be further expanded to test these changes, however, given the current coverage I don't think is necessary.