### PR TITLE
Fix wrong xml file encoding in some system

### DIFF
--- a/src/main/groovy/org/jetbrains/gradle/ext/IdeaFilesProcessor.groovy
+++ b/src/main/groovy/org/jetbrains/gradle/ext/IdeaFilesProcessor.groovy
@@ -22,6 +22,7 @@ import org.gradle.internal.xml.XmlTransformer
 import org.gradle.util.GradleVersion
 
 import javax.inject.Inject
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicBoolean
 
 @CompileStatic
@@ -116,7 +117,7 @@ class IdeaFilesProcessor {
             def transformer = new XmlTransformer()
             entry.value.each {transformer.addAction(it) }
             def result = transformer.transform(ideaFile.text)
-            ideaFile.write(result)
+            ideaFile.write(result, StandardCharsets.UTF_8.name())
         }
 
         imlsCallbacks.each { entry ->
@@ -139,7 +140,7 @@ class IdeaFilesProcessor {
             def transformer = new XmlTransformer()
             entry.value.each { transformer.addAction(it) }
             def result = transformer.transform(moduleFile.text)
-            moduleFile.write(result)
+            moduleFile.write(result, StandardCharsets.UTF_8.name())
         }
     }
 


### PR DESCRIPTION
In certain operating system environments, `Charset.defaultCharset().name()` does not return UTF-8, such as in the case of GBK.
 However, IDEA's XML configuration files should always be in UTF-8 format.
 So I pass the parameter that specifies the file encoding is UTF-8.