### PR TITLE
Properly declare service usage for the task

### DIFF
--- a/src/main/groovy/org/jetbrains/gradle/ext/IdeaFilesProcessor.groovy
+++ b/src/main/groovy/org/jetbrains/gradle/ext/IdeaFilesProcessor.groovy
@@ -53,6 +53,7 @@ class IdeaFilesProcessor {
                         new Action<ProcessIdeaFilesWithServiceTask>() {
                             @Override
                             void execute(ProcessIdeaFilesWithServiceTask task) {
+                                task.usesService(serviceProvider)
                                 task.service.set(serviceProvider)
                                 task.myProcessor = that
                             }


### PR DESCRIPTION
Without properly declaring the usage, the plugin will fail to execute with Gradle 8 when post-processing IDE files.
