### PR TITLE
Fix class property in JUnit runs

### DIFF
--- a/src/main/groovy/org/jetbrains/gradle/ext/RunConfigurations.groovy
+++ b/src/main/groovy/org/jetbrains/gradle/ext/RunConfigurations.groovy
@@ -311,7 +311,7 @@ class JUnit extends ModuleRunConfiguration {
                 "vmParameters"    : vmParameters,
                 "category"        : category,
                 "workingDirectory": workingDirectory,
-                "className"       : className,
+                "class"           : className,
                 "passParentEnvs"  : passParentEnvs,
                 "packageName"     : packageName,
                 "defaults"        : defaults,


### PR DESCRIPTION
`JUnit` run configurations using the `className` property are currently not correctly imported into IntelliJ IDEA. This is because the `JUnit` map entry should be `"class"` instead of `"className"`, see [JUnitRunConfigurationImporter](https://github.com/JetBrains/intellij-community/blob/01a2b60307f54bcb1410fa536040bdf13bceef39/plugins/junit/src/com/intellij/execution/junit/JUnitRunConfigurationImporter.kt#L39).


Fixes #92.